### PR TITLE
fixed link to manifesto page in navbar

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,5 @@
 class PagesController < ApplicationController
-  skip_before_action :authenticate_user!, only: :home
+  skip_before_action :authenticate_user!, only: [:home, :manifesto]
 
   def home
   end

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -13,7 +13,7 @@
       </div>
   <% else %>
     <div class="menu">
-      <p class="nav-link">Manifesto</p>
+      <%= link_to "Manifesto", manifesto_path, class: 'nav-link' %>
       <%= link_to "Députés", representatives_path, class: 'nav-link' %>
       <%= link_to "Lois", laws_path, class: 'nav-link' %>
       <div class="bar"></div>


### PR DESCRIPTION
I added the link to the manifesto item in the navbar when logged out and "skip_before_action :authenticate_user" for the manifesto page in the page controller